### PR TITLE
feat: Implement (truncated) expmodgauss distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ We provide JIT-compiled (with Numba) implementations of common probability distr
 - Cruijff density (not normalized to unity, use this in extended likelihood fits)
 - CMS-Shape
 - Generalized Argus
+- (Truncated) Exponentially Modified Gaussian
 
 The speed gains are huge, up to a factor of 100 compared to `scipy`. Benchmarks are included in the repository and are run by `pytest`.
 

--- a/src/numba_stats/__init__.py
+++ b/src/numba_stats/__init__.py
@@ -15,6 +15,7 @@ We provide numba-accelerated implementations of common probability distributions
 * Bernstein density (not normalized to unity, use this in extended likelihood fits)
 * Cruijff density (not normalized to unity, use this in extended likelihood fits)
 * CMS-Shape
+* (Truncated) Exponentially Modified Normal (exponnorm)
 
 The speed gains are huge, up to a factor of 100 compared to Scipy.
 

--- a/src/numba_stats/exponnorm.py
+++ b/src/numba_stats/exponnorm.py
@@ -1,7 +1,7 @@
-"""
+r"""
 Exponentially modified normal distribution.
 
-The distribution is defined as the distribution of the sum of a normal and 
+The distribution is defined as the distribution of the sum of a normal and
 exponential random variate. This definition has a right tail, but a left
 tailed version can be defined by taking the difference between a normal and
 exponential random variate instead.
@@ -10,17 +10,28 @@ To convert between the left- and right-tailed versions, a coordinate
 transformation x -> 2\mu - x can be used to reflect the x-axis.
 
 https://en.wikipedia.org/wiki/Exponentially_modified_Gaussian_distribution
+
 See Also
 --------
 scipy.stats.exponnorm: Scipy equivalent.
 """
 
-from math import erfc as _erfc, sqrt as _sqrt, exp as _exp, erf as _erf
+from math import erfc as _erfc
+from math import exp as _exp
+from math import sqrt as _sqrt
 
 import numpy as np
 
 from . import norm as _norm
-from ._util import _generate_wrappers, _jit, _jit_pointwise, _prange, _rvs_jit, _seed, _trans
+from ._util import (
+    _generate_wrappers,
+    _jit,
+    _jit_pointwise,
+    _prange,
+    _rvs_jit,
+    _seed,
+    _trans,
+)
 
 _doc_par = """
 loc : float
@@ -31,23 +42,26 @@ tau : float
     Exponential decay parameter.
 """
 
+
 @_jit_pointwise(4)
 def _pdf1(x: float, loc: float, scale: float, tau: float) -> float:
     T = type(x)
     sqrt2 = T(_sqrt(2))
-    arg1 = (scale ** 2) / (T(2) * tau ** 2) - (x - loc) / tau
+    arg1 = (scale**2) / (T(2) * tau**2) - (x - loc) / tau
     arg2 = (scale) / (sqrt2 * tau) - (x - loc) / (sqrt2 * scale)
     return T(1) / (T(2) * tau) * _exp(arg1) * _erfc(arg2)
+
 
 @_jit_pointwise(4)
 def _cdf1(x: float, loc: float, scale: float, tau: float) -> float:
     T = type(x)
     sqrt2 = T(_sqrt(2))
     half = T(0.5)
-    arg1 = (scale ** 2) / (T(2) * tau ** 2) - (x - loc) / tau
+    arg1 = (scale**2) / (T(2) * tau**2) - (x - loc) / tau
     z = _trans(x, loc, scale)
     arg2 = (scale) / (sqrt2 * tau) - (z / sqrt2)
     return _norm._cdf1(z) - half * _exp(arg1) * _erfc(arg2)
+
 
 @_jit(3)
 def _pdf(x: np.ndarray, loc: float, scale: float, tau: float) -> np.ndarray:
@@ -56,16 +70,21 @@ def _pdf(x: np.ndarray, loc: float, scale: float, tau: float) -> np.ndarray:
         r[i] = _pdf1(x[i], loc, scale, tau)
     return r
 
+
 @_jit(3)
-def _cdf(x: np.ndarray , loc: float, scale: float, tau: float) -> np.ndarray :
+def _cdf(x: np.ndarray, loc: float, scale: float, tau: float) -> np.ndarray:
     r = np.empty_like(x)
     for i in _prange(len(x)):
         r[i] = _cdf1(x[i], loc, scale, tau)
     return r
 
+
 @_rvs_jit(3)
-def _rvs(loc: float, scale: float, tau: float, size: int, random_state: int | None) -> np.ndarray:
+def _rvs(
+    loc: float, scale: float, tau: float, size: int, random_state: int | None
+) -> np.ndarray:
     _seed(random_state)
     return np.random.normal(loc, scale, size) + np.random.exponential(tau, size)
+
 
 _generate_wrappers(globals())

--- a/src/numba_stats/exponnorm.py
+++ b/src/numba_stats/exponnorm.py
@@ -1,0 +1,71 @@
+"""
+Exponentially modified normal distribution.
+
+The distribution is defined as the distribution of the sum of a normal and 
+exponential random variate. This definition has a right tail, but a left
+tailed version can be defined by taking the difference between a normal and
+exponential random variate instead.
+
+To convert between the left- and right-tailed versions, a coordinate
+transformation x -> 2\mu - x can be used to reflect the x-axis.
+
+https://en.wikipedia.org/wiki/Exponentially_modified_Gaussian_distribution
+See Also
+--------
+scipy.stats.exponnorm: Scipy equivalent.
+"""
+
+from math import erfc as _erfc, sqrt as _sqrt, exp as _exp, erf as _erf
+
+import numpy as np
+
+from . import norm as _norm
+from ._util import _generate_wrappers, _jit, _jit_pointwise, _prange, _rvs_jit, _seed, _trans
+
+_doc_par = """
+loc : float
+    Mode of unmodified normal distribution.
+scale : float
+    Standard deviation.
+tau : float
+    Exponential decay parameter.
+"""
+
+@_jit_pointwise(4)
+def _pdf1(x: float, loc: float, scale: float, tau: float) -> float:
+    T = type(x)
+    sqrt2 = T(_sqrt(2))
+    arg1 = (scale ** 2) / (T(2) * tau ** 2) - (x - loc) / tau
+    arg2 = (scale) / (sqrt2 * tau) - (x - loc) / (sqrt2 * scale)
+    return T(1) / (T(2) * tau) * _exp(arg1) * _erfc(arg2)
+
+@_jit_pointwise(4)
+def _cdf1(x: float, loc: float, scale: float, tau: float) -> float:
+    T = type(x)
+    sqrt2 = T(_sqrt(2))
+    half = T(0.5)
+    arg1 = (scale ** 2) / (T(2) * tau ** 2) - (x - loc) / tau
+    z = _trans(x, loc, scale)
+    arg2 = (scale) / (sqrt2 * tau) - (z / sqrt2)
+    return _norm._cdf1(z) - half * _exp(arg1) * _erfc(arg2)
+
+@_jit(3)
+def _pdf(x: np.ndarray, loc: float, scale: float, tau: float) -> np.ndarray:
+    r = np.empty_like(x)
+    for i in _prange(len(x)):
+        r[i] = _pdf1(x[i], loc, scale, tau)
+    return r
+
+@_jit(3)
+def _cdf(x: np.ndarray , loc: float, scale: float, tau: float) -> np.ndarray :
+    r = np.empty_like(x)
+    for i in _prange(len(x)):
+        r[i] = _cdf1(x[i], loc, scale, tau)
+    return r
+
+@_rvs_jit(3)
+def _rvs(loc: float, scale: float, tau: float, size: int, random_state: int | None) -> np.ndarray:
+    _seed(random_state)
+    return np.random.normal(loc, scale, size) + np.random.exponential(tau, size)
+
+_generate_wrappers(globals())

--- a/src/numba_stats/truncexponnorm.py
+++ b/src/numba_stats/truncexponnorm.py
@@ -1,0 +1,66 @@
+"""
+Truncated exponentially modified normal distribution.
+
+The distribution is defined as the distribution of the sum of a normal and 
+exponential random variate. This definition has a right tail, but a left
+tailed version can be defined by taking the difference between a normal and
+exponential random variate instead.
+
+To convert between the left- and right-tailed versions, a coordinate
+transformation x -> 2\mu - x can be used to reflect the x-axis.
+
+https://en.wikipedia.org/wiki/Exponentially_modified_Gaussian_distribution
+See Also
+--------
+scipy.stats.exponnorm: Untruncated scipy equivalent.
+"""
+
+from ._util import _jit, _generate_wrappers, _prange
+
+import numpy as np
+
+from . import exponnorm as _exponnorm
+
+_doc_par = """
+xmin : float
+    Lower edge of the distribution.
+xmax : float
+    Upper edge of the distribution.
+loc : float
+    Location parameter.
+scale : float
+    Scale parameter.
+tau : float
+    Exponential decay parameter.
+"""
+
+@_jit(5)
+def _pdf(x: np.ndarray, xmin: float, xmax: float, loc: float, scale: float, tau: float) -> np.ndarray:
+    T = type(scale)
+    pmin = _exponnorm._cdf1(xmin, loc, scale, tau)
+    pmax = _exponnorm._cdf1(xmax, loc, scale, tau)
+    r = np.zeros_like(x)
+    for i in _prange(len(x)):
+        if xmin <= x[i] < xmax:
+            r[i] = _exponnorm._pdf1(x[i], loc, scale, tau) / (pmax - pmin)
+        else:
+            r[i] = T(0.0)
+    return r
+
+@_jit(5)
+def _cdf(x: np.ndarray, xmin: float, xmax: float, loc: float, scale: float, tau: float) -> np.ndarray:
+    T = type(scale)
+    pmin = _exponnorm._cdf1(xmin, loc, scale, tau)
+    pmax = _exponnorm._cdf1(xmax, loc, scale, tau)
+    r = np.zeros_like(x)
+    for i in _prange(len(x)):
+            if xmin <= x[i]:
+                if x[i] < xmax:
+                    r[i] = (_exponnorm._cdf1(x[i], loc, scale, tau) - pmin) / (pmax - pmin)
+                else:
+                    r[i] = T(1.0)
+            else:
+                r[i] = T(0.0)
+    return r
+
+_generate_wrappers(globals())

--- a/src/numba_stats/truncexponnorm.py
+++ b/src/numba_stats/truncexponnorm.py
@@ -1,7 +1,7 @@
-"""
+r"""
 Truncated exponentially modified normal distribution.
 
-The distribution is defined as the distribution of the sum of a normal and 
+The distribution is defined as the distribution of the sum of a normal and
 exponential random variate. This definition has a right tail, but a left
 tailed version can be defined by taking the difference between a normal and
 exponential random variate instead.
@@ -10,16 +10,16 @@ To convert between the left- and right-tailed versions, a coordinate
 transformation x -> 2\mu - x can be used to reflect the x-axis.
 
 https://en.wikipedia.org/wiki/Exponentially_modified_Gaussian_distribution
+
 See Also
 --------
 scipy.stats.exponnorm: Untruncated scipy equivalent.
 """
 
-from ._util import _jit, _generate_wrappers, _prange
-
 import numpy as np
 
 from . import exponnorm as _exponnorm
+from ._util import _generate_wrappers, _jit, _prange
 
 _doc_par = """
 xmin : float
@@ -34,8 +34,11 @@ tau : float
     Exponential decay parameter.
 """
 
+
 @_jit(5)
-def _pdf(x: np.ndarray, xmin: float, xmax: float, loc: float, scale: float, tau: float) -> np.ndarray:
+def _pdf(
+    x: np.ndarray, xmin: float, xmax: float, loc: float, scale: float, tau: float
+) -> np.ndarray:
     T = type(scale)
     pmin = _exponnorm._cdf1(xmin, loc, scale, tau)
     pmax = _exponnorm._cdf1(xmax, loc, scale, tau)
@@ -47,20 +50,24 @@ def _pdf(x: np.ndarray, xmin: float, xmax: float, loc: float, scale: float, tau:
             r[i] = T(0.0)
     return r
 
+
 @_jit(5)
-def _cdf(x: np.ndarray, xmin: float, xmax: float, loc: float, scale: float, tau: float) -> np.ndarray:
+def _cdf(
+    x: np.ndarray, xmin: float, xmax: float, loc: float, scale: float, tau: float
+) -> np.ndarray:
     T = type(scale)
     pmin = _exponnorm._cdf1(xmin, loc, scale, tau)
     pmax = _exponnorm._cdf1(xmax, loc, scale, tau)
     r = np.zeros_like(x)
     for i in _prange(len(x)):
-            if xmin <= x[i]:
-                if x[i] < xmax:
-                    r[i] = (_exponnorm._cdf1(x[i], loc, scale, tau) - pmin) / (pmax - pmin)
-                else:
-                    r[i] = T(1.0)
+        if xmin <= x[i]:
+            if x[i] < xmax:
+                r[i] = (_exponnorm._cdf1(x[i], loc, scale, tau) - pmin) / (pmax - pmin)
             else:
-                r[i] = T(0.0)
+                r[i] = T(1.0)
+        else:
+            r[i] = T(0.0)
     return r
+
 
 _generate_wrappers(globals())

--- a/tests/test_exponnorm.py
+++ b/tests/test_exponnorm.py
@@ -3,7 +3,9 @@ import numpy as np
 import pytest
 import scipy.stats as sc
 from numpy.testing import assert_allclose
+
 from numba_stats import exponnorm
+
 
 def test_pdf_one():
     x = 1
@@ -11,9 +13,10 @@ def test_pdf_one():
     sigma = 2
     tau = 3
     K = tau / sigma
-    got = exponnorm.pdf(x, mu, sigma ,tau)
+    got = exponnorm.pdf(x, mu, sigma, tau)
     expected = sc.exponnorm.pdf(x, K, loc=mu, scale=sigma)
     assert_allclose(got, expected)
+
 
 def test_pdf():
     mu = 1
@@ -25,6 +28,7 @@ def test_pdf():
     expected = sc.exponnorm.pdf(x, K, loc=mu, scale=sigma)
     assert_allclose(got, expected)
 
+
 def test_cdf_one():
     x = 1
     mu = 1
@@ -35,6 +39,7 @@ def test_cdf_one():
     expected = sc.exponnorm.cdf(x, K, loc=mu, scale=sigma)
     assert_allclose(got, expected)
 
+
 def test_cdf():
     mu = 1
     sigma = 2
@@ -44,6 +49,7 @@ def test_cdf():
     got = exponnorm.cdf(x, mu, sigma, tau)
     expected = sc.exponnorm.cdf(x, K, loc=mu, scale=sigma)
     assert_allclose(got, expected)
+
 
 def test_rvs():
     mu = 2
@@ -66,6 +72,7 @@ def test_njit(fn, parallel):
     y = test(x)
 
     assert_allclose(y, fn(x, 0, 1, 2))
+
 
 @pytest.mark.filterwarnings("error")
 def test_rvs_njit():

--- a/tests/test_exponnorm.py
+++ b/tests/test_exponnorm.py
@@ -1,0 +1,76 @@
+import numba as nb
+import numpy as np
+import pytest
+import scipy.stats as sc
+from numpy.testing import assert_allclose
+from numba_stats import exponnorm
+
+def test_pdf_one():
+    x = 1
+    mu = 1
+    sigma = 2
+    tau = 3
+    K = tau / sigma
+    got = exponnorm.pdf(x, mu, sigma ,tau)
+    expected = sc.exponnorm.pdf(x, K, loc=mu, scale=sigma)
+    assert_allclose(got, expected)
+
+def test_pdf():
+    mu = 1
+    sigma = 2
+    tau = 3
+    K = tau / sigma
+    x = np.linspace(-5, 5, 10)
+    got = exponnorm.pdf(x, mu, sigma, tau)
+    expected = sc.exponnorm.pdf(x, K, loc=mu, scale=sigma)
+    assert_allclose(got, expected)
+
+def test_cdf_one():
+    x = 1
+    mu = 1
+    sigma = 2
+    tau = 3
+    K = tau / sigma
+    got = exponnorm.cdf(x, mu, sigma, tau)
+    expected = sc.exponnorm.cdf(x, K, loc=mu, scale=sigma)
+    assert_allclose(got, expected)
+
+def test_cdf():
+    mu = 1
+    sigma = 2
+    tau = 3
+    K = tau / sigma
+    x = np.linspace(-5, 5, 10)
+    got = exponnorm.cdf(x, mu, sigma, tau)
+    expected = sc.exponnorm.cdf(x, K, loc=mu, scale=sigma)
+    assert_allclose(got, expected)
+
+def test_rvs():
+    mu = 2
+    sigma = 3
+    tau = 2
+    x = exponnorm.rvs(mu, sigma, tau, size=100_000, random_state=1)
+    r = sc.kstest(x, lambda x: exponnorm.cdf(x, mu, sigma, tau))
+    assert r.pvalue > 0.01
+
+
+@pytest.mark.filterwarnings("error")
+@pytest.mark.parametrize("fn", [exponnorm.pdf, exponnorm.cdf])
+@pytest.mark.parametrize("parallel", [False, True])
+def test_njit(fn, parallel):
+    @nb.njit(parallel=parallel, fastmath=True)
+    def test(x):
+        return fn(x, 0.0, 1.0, 2.0)
+
+    x = np.linspace(-3, 3, 1000)
+    y = test(x)
+
+    assert_allclose(y, fn(x, 0, 1, 2))
+
+@pytest.mark.filterwarnings("error")
+def test_rvs_njit():
+    @nb.njit
+    def test():
+        return exponnorm.rvs(0.0, 1.0, 2.0, 10, 1)
+
+    assert_allclose(test(), exponnorm.rvs(0, 1, 2, 10, 1))

--- a/tests/test_truncexponnorm.py
+++ b/tests/test_truncexponnorm.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pytest
+import scipy.stats as sc
+from scipy.integrate import quad
+
+from numba_stats import truncexponnorm
+
+
+@pytest.mark.parametrize("mu", (0, -1, 1))
+@pytest.mark.parametrize("sigma", (1, 0.5, 2))
+@pytest.mark.parametrize("tau", (1, 2, 3))
+def test_truncnorm(mu, sigma, tau):
+    got = quad(lambda x: truncexponnorm.pdf(x, -1, 1, mu, sigma, tau), -10, 10)[0]
+    expected = 1.0
+    np.testing.assert_allclose(got, expected)
+
+def test_pdf():
+    x = np.linspace(-1, 5, 10)
+    xmin = 1
+    xmax = 4
+    mu = 2
+    sigma = 3
+    tau = 1
+    K = tau / sigma
+    got = truncexponnorm.pdf(x, xmin, xmax, mu, sigma, tau)
+    # We have to manually truncate the distribution since scipy doesn't provide one
+    pmin = sc.exponnorm.cdf(xmin, K, loc=mu, scale=sigma)
+    pmax = sc.exponnorm.cdf(xmax, K, loc=mu, scale=sigma)
+    expected = np.where((xmin <= x) & (x < xmax), sc.exponnorm.pdf(x, K, loc=mu, scale=sigma) / (pmax - pmin), 0.0)
+    np.testing.assert_allclose(got, expected)
+
+
+def test_cdf():
+    x = np.linspace(-1, 5, 10)
+    xmin = 1
+    xmax = 4
+    mu = 2
+    sigma = 3
+    tau = 1
+    K = tau / sigma
+    got = truncexponnorm.cdf(x, xmin, xmax, mu, sigma, tau)
+    # We have to manually truncate the distribution since scipy doesn't provide one
+    pmin = sc.exponnorm.cdf(xmin, K, loc=mu, scale=sigma)
+    pmax = sc.exponnorm.cdf(xmax, K, loc=mu, scale=sigma)
+    expected = np.where(x < xmin, 0.0, np.where(x > xmax, 1.0, (sc.exponnorm.cdf(x, K, loc=mu, scale=sigma) - pmin) / (pmax - pmin)))
+    np.testing.assert_allclose(got, expected)

--- a/tests/test_truncexponnorm.py
+++ b/tests/test_truncexponnorm.py
@@ -14,6 +14,7 @@ def test_truncnorm(mu, sigma, tau):
     expected = 1.0
     np.testing.assert_allclose(got, expected)
 
+
 def test_pdf():
     x = np.linspace(-1, 5, 10)
     xmin = 1
@@ -26,7 +27,11 @@ def test_pdf():
     # We have to manually truncate the distribution since scipy doesn't provide one
     pmin = sc.exponnorm.cdf(xmin, K, loc=mu, scale=sigma)
     pmax = sc.exponnorm.cdf(xmax, K, loc=mu, scale=sigma)
-    expected = np.where((xmin <= x) & (x < xmax), sc.exponnorm.pdf(x, K, loc=mu, scale=sigma) / (pmax - pmin), 0.0)
+    expected = np.where(
+        (xmin <= x) & (x < xmax),
+        sc.exponnorm.pdf(x, K, loc=mu, scale=sigma) / (pmax - pmin),
+        0.0,
+    )
     np.testing.assert_allclose(got, expected)
 
 
@@ -42,5 +47,13 @@ def test_cdf():
     # We have to manually truncate the distribution since scipy doesn't provide one
     pmin = sc.exponnorm.cdf(xmin, K, loc=mu, scale=sigma)
     pmax = sc.exponnorm.cdf(xmax, K, loc=mu, scale=sigma)
-    expected = np.where(x < xmin, 0.0, np.where(x > xmax, 1.0, (sc.exponnorm.cdf(x, K, loc=mu, scale=sigma) - pmin) / (pmax - pmin)))
+    expected = np.where(
+        x < xmin,
+        0.0,
+        np.where(
+            x > xmax,
+            1.0,
+            (sc.exponnorm.cdf(x, K, loc=mu, scale=sigma) - pmin) / (pmax - pmin),
+        ),
+    )
     np.testing.assert_allclose(got, expected)


### PR DESCRIPTION
Implements the right-tailed version of exponentially modified gaussian distribution. This matches the convention scipy.stats.exponnorm uses. The left-tailed version is related by a coordinate transformation x -> 2\mu - x.

The left-tailed version of this distribution is used very commonly to fit gamma lines from data. The exponential modification can be understood to model signal loss in your detector. ROOT's equivalent function is [here](https://root.cern.ch/doc/v638/classRooGExpModel.html).