### PR TITLE
feat: Implement Skewnorm distributon

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ We provide JIT-compiled (with Numba) implementations of common probability distr
 - Cruijff density (not normalized to unity, use this in extended likelihood fits)
 - CMS-Shape
 - Generalized Argus
+- Skewnorm
 
 The speed gains are huge, up to a factor of 100 compared to `scipy`. Benchmarks are included in the repository and are run by `pytest`.
 

--- a/src/numba_stats/__init__.py
+++ b/src/numba_stats/__init__.py
@@ -15,6 +15,7 @@ We provide numba-accelerated implementations of common probability distributions
 * Bernstein density (not normalized to unity, use this in extended likelihood fits)
 * Cruijff density (not normalized to unity, use this in extended likelihood fits)
 * CMS-Shape
+* Skewnorm
 
 The speed gains are huge, up to a factor of 100 compared to Scipy.
 

--- a/src/numba_stats/_special.py
+++ b/src/numba_stats/_special.py
@@ -39,6 +39,7 @@ gammainc = get("gammainc", float64(float64, float64))
 gammaincc = get("gammaincc", float64(float64, float64))
 stdtrit = get("stdtrit", float64(float64, float64))
 stdtr = get("stdtr", float64(float64, float64))
+owens_t = get("owens_t", float64(float64, float64))
 
 # n-ary functions (double)
 voigt_profile = get("voigt_profile", float64(float64, float64, float64))

--- a/src/numba_stats/skewnorm.py
+++ b/src/numba_stats/skewnorm.py
@@ -35,7 +35,7 @@ a : float
 @_jit_pointwise(2)
 def _logpdf1(z: float, a: float) -> float:
     T = type(z)
-    return T(np.log(2)) + _norm._logpdf1(z) + np.log(_norm._cdf1(a * z))
+    return T(np.log(2)) + _norm._logpdf1(z) + T(np.log(_norm._cdf1(a * z)))
 
 
 @_jit(3)

--- a/src/numba_stats/skewnorm.py
+++ b/src/numba_stats/skewnorm.py
@@ -2,17 +2,25 @@
 Skewed normal distribution.
 
 https://en.wikipedia.org/wiki/Skew_normal_distribution
+
 See Also
 --------
 scipy.stats.skewnorm: Scipy equivalent.
 """
 
-from ._special import owens_t as _owens_t
-from ._util import _jit, _jit_pointwise, _generate_wrappers, _trans, _rvs_jit, _seed, _prange
-
 import numpy as np
 
 from . import norm as _norm
+from ._special import owens_t as _owens_t
+from ._util import (
+    _generate_wrappers,
+    _jit,
+    _jit_pointwise,
+    _prange,
+    _rvs_jit,
+    _seed,
+    _trans,
+)
 
 _doc_par = """
 loc : float
@@ -23,10 +31,12 @@ a : float
     Skewness parameter.
 """
 
+
 @_jit_pointwise(2)
 def _logpdf1(z: float, a: float) -> float:
     T = type(z)
     return T(np.log(2)) + _norm._logpdf1(z) + np.log(_norm._cdf1(a * z))
+
 
 @_jit(3)
 def _logpdf(x: np.ndarray, loc: float, scale: float, a: float) -> np.ndarray:
@@ -35,31 +45,38 @@ def _logpdf(x: np.ndarray, loc: float, scale: float, a: float) -> np.ndarray:
         r[i] = _logpdf1(r[i], a) - np.log(scale)
     return r
 
+
 @_jit(3)
 def _pdf(x: np.ndarray, loc: float, scale: float, a: float) -> np.ndarray:
     return np.exp(_logpdf(x, loc, scale, a))
+
 
 @_jit_pointwise(2, cache=False)
 def _cdf1(z: float, a: float) -> float:
     T = type(z)
     return _norm._cdf1(z) - T(2) * T(_owens_t(z, a))
 
+
 @_jit(3, cache=False)
-def _cdf(x: np.ndarray , loc: float, scale: float, a: float) -> np.ndarray :
+def _cdf(x: np.ndarray, loc: float, scale: float, a: float) -> np.ndarray:
     r = _trans(x, loc, scale)
     for i in _prange(len(x)):
         r[i] = _cdf1(r[i], a)
     return r
 
+
 @_rvs_jit(3)
-def _rvs(loc: float, scale: float, a: float, size: int, random_state: int | None) -> np.ndarray:
+def _rvs(
+    loc: float, scale: float, a: float, size: int, random_state: int | None
+) -> np.ndarray:
     _seed(random_state)
     # Implementation taken from scipy
     # https://github.com/scipy/scipy/blob/v1.18.0/scipy/stats/_continuous_distns.py#L9724-L9946
     u0 = np.random.normal(loc=0, scale=1, size=size)
     v = np.random.normal(loc=0, scale=1, size=size)
-    d = a / np.sqrt(1 + a ** 2)
-    u1 = d * u0 + v * np.sqrt(1 - d ** 2)
+    d = a / np.sqrt(1 + a**2)
+    u1 = d * u0 + v * np.sqrt(1 - d**2)
     return loc + scale * np.where(u0 >= 0, u1, -u1)
+
 
 _generate_wrappers(globals())

--- a/src/numba_stats/skewnorm.py
+++ b/src/numba_stats/skewnorm.py
@@ -76,7 +76,10 @@ def _rvs(
     v = np.random.normal(loc=0, scale=1, size=size)
     d = a / np.sqrt(1 + a**2)
     u1 = d * u0 + v * np.sqrt(1 - d**2)
-    return loc + scale * np.where(u0 >= 0, u1, -u1)
+    if u0 >= 0:
+        return loc + scale * u1
+    else:
+        return loc - scale * u1
 
 
 _generate_wrappers(globals())

--- a/src/numba_stats/skewnorm.py
+++ b/src/numba_stats/skewnorm.py
@@ -76,10 +76,7 @@ def _rvs(
     v = np.random.normal(loc=0, scale=1, size=size)
     d = a / np.sqrt(1 + a**2)
     u1 = d * u0 + v * np.sqrt(1 - d**2)
-    if u0 >= 0:
-        return loc + scale * u1
-    else:
-        return loc - scale * u1
+    return loc + scale * np.where(u0 >= 0, u1, -u1)
 
 
 _generate_wrappers(globals())

--- a/src/numba_stats/skewnorm.py
+++ b/src/numba_stats/skewnorm.py
@@ -1,0 +1,64 @@
+"""
+Skewed normal distribution.
+
+See Also
+--------
+scipy.stats.skewnorm: Scipy equivalent.
+"""
+
+from ._special import owens_t as _owens_t
+from ._util import _jit, _jit_pointwise, _generate_wrappers, _trans, _rvs_jit, _seed, _prange
+
+import numpy as np
+
+from . import norm as _norm
+
+_doc_par = """
+loc : float
+    Location parameter.
+scale : float
+    Scale parameter.
+a : float
+    Skewness parameter.
+"""
+
+@_jit_pointwise(2)
+def _logpdf1(z: float, a: float) -> float:
+    T = type(z)
+    return T(np.log(2)) + _norm._logpdf1(z) + np.log(_norm._cdf1(a * z))
+
+@_jit(3)
+def _logpdf(x: np.ndarray, loc: float, scale: float, a: float) -> np.ndarray:
+    r = _trans(x, loc, scale)
+    for i in _prange(len(r)):
+        r[i] = _logpdf1(r[i], a) - np.log(scale)
+    return r
+
+@_jit(3)
+def _pdf(x: np.ndarray, loc: float, scale: float, a: float) -> np.ndarray:
+    return np.exp(_logpdf(x, loc, scale, a))
+
+@_jit_pointwise(2, cache=False)
+def _cdf1(z: float, a: float) -> float:
+    T = type(z)
+    return _norm._cdf1(z) - T(2) * T(_owens_t(z, a))
+
+@_jit(3, cache=False)
+def _cdf(x: np.ndarray , loc: float, scale: float, a: float) -> np.ndarray :
+    r = _trans(x, loc, scale)
+    for i in _prange(len(x)):
+        r[i] = _cdf1(r[i], a)
+    return r
+
+@_rvs_jit(3)
+def _rvs(loc: float, scale: float, a: float, size: int, random_state: int | None) -> np.ndarray:
+    _seed(random_state)
+    # Implementation taken from scipy
+    # https://github.com/scipy/scipy/blob/v1.18.0/scipy/stats/_continuous_distns.py#L9724-L9946
+    u0 = np.random.normal(loc=0, scale=1, size=size)
+    v = np.random.normal(loc=0, scale=1, size=size)
+    d = a / np.sqrt(1 + a ** 2)
+    u1 = d * u0 + v * np.sqrt(1 - d ** 2)
+    return loc + scale * np.where(u0 >= 0, u1, -u1)
+
+_generate_wrappers(globals())

--- a/src/numba_stats/skewnorm.py
+++ b/src/numba_stats/skewnorm.py
@@ -8,6 +8,8 @@ See Also
 scipy.stats.skewnorm: Scipy equivalent.
 """
 
+from math import sqrt as _sqrt
+
 import numpy as np
 
 from . import norm as _norm
@@ -74,8 +76,8 @@ def _rvs(
     # https://github.com/scipy/scipy/blob/v1.18.0/scipy/stats/_continuous_distns.py#L9724-L9946
     u0 = np.random.normal(loc=0, scale=1, size=size)
     v = np.random.normal(loc=0, scale=1, size=size)
-    d = a / np.sqrt(1 + a**2)
-    u1 = d * u0 + v * np.sqrt(1 - d**2)
+    d = a / _sqrt(1 + a**2)
+    u1 = d * u0 + v * _sqrt(1 - d**2)
     return loc + scale * np.where(u0 >= 0, u1, -u1)
 
 

--- a/src/numba_stats/skewnorm.py
+++ b/src/numba_stats/skewnorm.py
@@ -1,6 +1,7 @@
 """
 Skewed normal distribution.
 
+https://en.wikipedia.org/wiki/Skew_normal_distribution
 See Also
 --------
 scipy.stats.skewnorm: Scipy equivalent.

--- a/tests/test_skewnorm.py
+++ b/tests/test_skewnorm.py
@@ -1,0 +1,56 @@
+import numba as nb
+import numpy as np
+import pytest
+import scipy.stats as sc
+from numpy.testing import assert_allclose
+
+from numba_stats import skewnorm
+
+def test_pdf_one():
+    x = 1
+    got = skewnorm.pdf(x, 1, 2, 3)
+    expected = sc.skewnorm.pdf(x, 3, loc=1, scale=2)
+    assert_allclose(got, expected, atol=1e-16)
+
+
+def test_pdf():
+    x = np.linspace(-5, 5, 10)
+    got = skewnorm.pdf(x, 1, 2, 3)
+    expected = sc.skewnorm.pdf(x, 3, loc=1, scale=2)
+    assert_allclose(got, expected, atol=1e-16)
+
+def test_cdf():
+    x = np.linspace(-5, 5, 10)
+    got = skewnorm.cdf(x, 1, 2, 3)
+    expected = sc.skewnorm.cdf(x, 3, loc=1, scale=2)
+    assert_allclose(got, expected, atol=1e-16)
+
+def test_rvs():
+    mu = 2
+    sigma = 3
+    a = 2
+    x = skewnorm.rvs(mu, sigma, a, size=100_000, random_state=1)
+    r = sc.kstest(x, lambda x: skewnorm.cdf(x, mu, sigma, a))
+    assert r.pvalue > 0.01
+
+
+@pytest.mark.filterwarnings("error")
+@pytest.mark.parametrize("fn", [skewnorm.pdf, skewnorm.cdf])
+@pytest.mark.parametrize("parallel", [False, True])
+def test_njit(fn, parallel):
+    @nb.njit(parallel=parallel, fastmath=True)
+    def test(x):
+        return fn(x, 0.0, 1.0, 2.0)
+
+    x = np.linspace(-3, 3, 1000)
+    y = test(x)
+
+    assert_allclose(y, fn(x, 0, 1, 2))
+
+@pytest.mark.filterwarnings("error")
+def test_rvs_njit():
+    @nb.njit
+    def test():
+        return skewnorm.rvs(0.0, 1.0, 2.0, 10, 1)
+
+    assert_allclose(test(), skewnorm.rvs(0, 1, 2, 10, 1))

--- a/tests/test_skewnorm.py
+++ b/tests/test_skewnorm.py
@@ -6,6 +6,7 @@ from numpy.testing import assert_allclose
 
 from numba_stats import skewnorm
 
+
 def test_pdf_one():
     x = 1
     got = skewnorm.pdf(x, 1, 2, 3)
@@ -19,11 +20,13 @@ def test_pdf():
     expected = sc.skewnorm.pdf(x, 3, loc=1, scale=2)
     assert_allclose(got, expected, atol=1e-16)
 
+
 def test_cdf():
     x = np.linspace(-5, 5, 10)
     got = skewnorm.cdf(x, 1, 2, 3)
     expected = sc.skewnorm.cdf(x, 3, loc=1, scale=2)
     assert_allclose(got, expected, atol=1e-16)
+
 
 def test_rvs():
     mu = 2
@@ -46,6 +49,7 @@ def test_njit(fn, parallel):
     y = test(x)
 
     assert_allclose(y, fn(x, 0, 1, 2))
+
 
 @pytest.mark.filterwarnings("error")
 def test_rvs_njit():


### PR DESCRIPTION
Implements the SkewNorm distribution.

Tests based on comparison of rtol values fail, since the implementation is slightly different between here and scipy. However, setting atol=1e-16 allows tests to pass.