### PR TITLE
feat: Implement chi2, ncx2, gamma distributions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ We provide JIT-compiled (with Numba) implementations of common probability distr
 - Cruijff density (not normalized to unity, use this in extended likelihood fits)
 - CMS-Shape
 - Generalized Argus
+- (Noncentral) Chi2
+- Gamma
 
 The speed gains are huge, up to a factor of 100 compared to `scipy`. Benchmarks are included in the repository and are run by `pytest`.
 

--- a/src/numba_stats/__init__.py
+++ b/src/numba_stats/__init__.py
@@ -15,6 +15,8 @@ We provide numba-accelerated implementations of common probability distributions
 * Bernstein density (not normalized to unity, use this in extended likelihood fits)
 * Cruijff density (not normalized to unity, use this in extended likelihood fits)
 * CMS-Shape
+* (Noncentral) Chi2
+* Gamma
 
 The speed gains are huge, up to a factor of 100 compared to Scipy.
 

--- a/src/numba_stats/_special.py
+++ b/src/numba_stats/_special.py
@@ -13,7 +13,7 @@ def get(name: str, signature: Any) -> Any:
     from scipy.special import cython_special
 
     # scipy-1.12 started to provide fused versions for some special functions
-    if name in {"betainc", "stdtr", "stdtrit"}:
+    if name in {"betainc", "stdtr", "stdtrit", "chndtr", "chndtrix"}:
         fuse_name = f"__pyx_fuse_0{name}"
     else:
         fuse_name = f"__pyx_fuse_1{name}"
@@ -33,15 +33,20 @@ def get(name: str, signature: Any) -> Any:
 
 # unary functions (double)
 ndtri = get("ndtri", float64(float64))
+gammaln = get("gammaln", float64(float64))
 
 # binary functions (double)
 gammainc = get("gammainc", float64(float64, float64))
 gammaincc = get("gammaincc", float64(float64, float64))
+gammaincinv = get("gammaincinv", float64(float64, float64))
 stdtrit = get("stdtrit", float64(float64, float64))
 stdtr = get("stdtr", float64(float64, float64))
+ive = get("ive", float64(float64, float64))
 
 # n-ary functions (double)
 voigt_profile = get("voigt_profile", float64(float64, float64, float64))
 xlogy = get("xlogy", float64(float64, float64))
 xlog1py = get("xlog1py", float64(float64, float64))
 betainc = get("betainc", float64(float64, float64, float64))
+chndtr = get("chndtr", float64(float64, float64, float64))
+chndtrix = get("chndtrix", float64(float64, float64, float64))

--- a/src/numba_stats/chi2.py
+++ b/src/numba_stats/chi2.py
@@ -1,0 +1,99 @@
+"""
+Chi squared distribution.
+
+See Also
+--------
+scipy.stats.chi2: Scipy equivalent.
+"""
+
+import numpy as np
+
+from ._special import gammaincc as _gammaincc
+from ._special import gammaincinv as _gammaincinv
+from ._special import gammaln as _gammaln
+from ._util import (
+    _generate_wrappers,
+    _jit,
+    _jit_pointwise,
+    _prange,
+    _rvs_jit,
+    _seed,
+    _trans,
+)
+
+_doc_par = """
+df: float
+    Degrees of freedom.
+loc: float
+    Location parameter.
+scale: float
+    Scale parameter.
+"""
+
+
+@_jit_pointwise(2, cache=False)
+def _logpdf1(z: float, df: float) -> float:
+    T = type(z)
+    half = T(0.5)
+    log2 = T(np.log(2))
+    return (
+        (half * df - T(1)) * T(np.log(z))
+        - half * z
+        - T(_gammaln(half * df))
+        - half * df * log2
+    )
+
+
+@_jit_pointwise(2, cache=False)
+def _cdf1(z: float, df: float) -> float:
+    T = type(z)
+    half = T(0.5)
+    return T(1) - T(_gammaincc(half * df, half * z))
+
+
+@_jit_pointwise(2, cache=False)
+def _ppf1(p: float, df: float) -> float:
+    T = type(p)
+    return T(2.0 * _gammaincinv(0.5 * df, p))
+
+
+@_jit(3, cache=False)
+def _logpdf(x: np.ndarray, df: float, loc: float, scale: float) -> np.ndarray:
+    r = _trans(x, loc, scale)
+    for i in _prange(len(r)):
+        r[i] = _logpdf1(r[i], df) - np.log(scale)
+    return r
+
+
+@_jit(3, cache=False)
+def _pdf(x: np.ndarray, df: float, loc: float, scale: float) -> np.ndarray:
+    return np.exp(_logpdf(x, df, loc, scale))
+
+
+@_jit(3, cache=False)
+def _cdf(x: np.ndarray, df: float, loc: float, scale: float) -> np.ndarray:
+    r = _trans(x, loc, scale)
+    for i in _prange(len(r)):
+        r[i] = _cdf1(r[i], df)
+    return r
+
+
+@_jit(3, cache=False)
+def _ppf(p: np.ndarray, df: float, loc: float, scale: float) -> np.ndarray:
+    r = np.empty_like(p)
+    for i in _prange(len(r)):
+        r[i] = scale * _ppf1(p[i], df) + loc
+    return r
+
+
+@_rvs_jit(3, cache=False)
+def _rvs(
+    df: float, loc: float, scale: float, size: int, random_state: int | None
+) -> np.ndarray:
+    _seed(random_state)
+    # Inverse transform sampling
+    u = np.random.uniform(0, 1, size)
+    return _ppf(u, df, loc, scale)
+
+
+_generate_wrappers(globals())

--- a/src/numba_stats/gamma.py
+++ b/src/numba_stats/gamma.py
@@ -1,0 +1,79 @@
+"""
+Gamma distribution.
+
+See Also
+--------
+scipy.stats.gamma: Scipy equivalent.
+"""
+
+import numpy as np
+
+from ._special import gammaincc as _gammaincc
+from ._special import gammaincinv as _gammaincinv
+from ._special import gammaln as _gammaln
+from ._util import (
+    _generate_wrappers,
+    _jit,
+    _jit_pointwise,
+    _prange,
+    _trans,
+)
+
+_doc_par = """
+alpha: float
+    Shape parameter.
+loc: float
+    Location parameter.
+scale: float
+    Scale parameter.
+"""
+
+
+@_jit_pointwise(2, cache=False)
+def _logpdf1(z: float, alpha: float) -> float:
+    T = type(z)
+    return (alpha - T(1)) * T(np.log(z)) - z - T(_gammaln(alpha))
+
+
+@_jit_pointwise(2, cache=False)
+def _cdf1(z: float, alpha: float) -> float:
+    T = type(z)
+    return T(1) - T(_gammaincc(alpha, z))
+
+
+@_jit_pointwise(2, cache=False)
+def _ppf1(p: float, alpha: float) -> float:
+    T = type(p)
+    return T(_gammaincinv(alpha, p))
+
+
+@_jit(3, cache=False)
+def _logpdf(x: np.ndarray, alpha: float, loc: float, scale: float) -> np.ndarray:
+    r = _trans(x, loc, scale)
+    for i in _prange(len(r)):
+        r[i] = _logpdf1(r[i], alpha) - np.log(scale)
+    return r
+
+
+@_jit(3, cache=False)
+def _pdf(x: np.ndarray, alpha: float, loc: float, scale: float) -> np.ndarray:
+    return np.exp(_logpdf(x, alpha, loc, scale))
+
+
+@_jit(3, cache=False)
+def _cdf(x: np.ndarray, alpha: float, loc: float, scale: float) -> np.ndarray:
+    r = _trans(x, loc, scale)
+    for i in _prange(len(r)):
+        r[i] = _cdf1(r[i], alpha)
+    return r
+
+
+@_jit(3, cache=False)
+def _ppf(p: np.ndarray, alpha: float, loc: float, scale: float) -> np.ndarray:
+    r = np.empty_like(p)
+    for i in _prange(len(r)):
+        r[i] = scale * _ppf1(p[i], alpha) + loc
+    return r
+
+
+_generate_wrappers(globals())

--- a/src/numba_stats/ncx2.py
+++ b/src/numba_stats/ncx2.py
@@ -1,0 +1,95 @@
+"""
+Noncentral chi squared distribution.
+
+See Also
+--------
+scipy.stats.ncx2: Scipy equivalent.
+"""
+
+import numpy as np
+
+from ._special import chndtr as _chndtr
+from ._special import chndtrix as _chndtrix
+from ._special import ive as _ive
+from ._special import xlogy as _xlogy
+from ._util import (
+    _generate_wrappers,
+    _jit,
+    _jit_pointwise,
+    _prange,
+    _trans,
+)
+
+_doc_par = """
+df: float
+    Degrees of freedom.
+nc: float
+    Noncentrality parameter.
+loc: float
+    Location parameter.
+scale: float
+    Scale parameter.
+"""
+
+
+@_jit_pointwise(3, cache=False)
+def _logpdf1(z: float, df: float, nc: float) -> float:
+    # Implementation from scipy
+    # https://github.com/scipy/scipy/blob/54ef5423f2e4376230ec3bfda6912a07a50958e3/scipy/stats/_continuous_distns.py#L7811
+    T = type(z)
+    two = T(2.0)
+    df2 = df / two - T(1.0)
+    zs = T(np.sqrt(z))
+    ns = T(np.sqrt(nc))
+    res = _xlogy(df2 / two, z / nc) - T(0.5) * (zs - ns) ** 2
+    corr = _ive(df2, zs * ns) / two
+    if corr > 0:
+        return T(res + np.log(corr))
+    else:
+        return -T(np.inf)
+
+
+@_jit_pointwise(3, cache=False)
+def _cdf1(z: float, df: float, nc: float) -> float:
+    T = type(z)
+    return T(_chndtr(z, df, nc))
+
+
+@_jit_pointwise(3, cache=False)
+def _ppf1(p: float, df: float, nc: float) -> float:
+    T = type(p)
+    return T(_chndtrix(p, df, nc))
+
+
+@_jit(4, cache=False)
+def _logpdf(
+    x: np.ndarray, df: float, nc: float, loc: float, scale: float
+) -> np.ndarray:
+    r = _trans(x, loc, scale)
+    for i in _prange(len(r)):
+        r[i] = _logpdf1(r[i], df, nc) - np.log(scale)
+    return r
+
+
+@_jit(4, cache=False)
+def _pdf(x: np.ndarray, df: float, nc: float, loc: float, scale: float) -> np.ndarray:
+    return np.exp(_logpdf(x, df, nc, loc, scale))
+
+
+@_jit(4, cache=False)
+def _cdf(x: np.ndarray, df: float, nc: float, loc: float, scale: float) -> np.ndarray:
+    r = _trans(x, loc, scale)
+    for i in _prange(len(r)):
+        r[i] = _cdf1(r[i], df, nc)
+    return r
+
+
+@_jit(4, cache=False)
+def _ppf(p: np.ndarray, df: float, nc: float, loc: float, scale: float) -> np.ndarray:
+    r = np.empty_like(p)
+    for i in _prange(len(r)):
+        r[i] = scale * _ppf1(p[i], df, nc) + loc
+    return r
+
+
+_generate_wrappers(globals())

--- a/tests/test_chi2.py
+++ b/tests/test_chi2.py
@@ -1,0 +1,85 @@
+import numba as nb
+import numpy as np
+import pytest
+import scipy.stats as sc
+from numpy.testing import assert_allclose
+
+from numba_stats import chi2
+
+
+def test_pdf_one():
+    df = 1
+    loc = 2
+    scale = 3
+    x = loc + 1
+    got = chi2.pdf(x, df, loc, scale)
+    expected = sc.chi2.pdf(x, df, loc=loc, scale=scale)
+    assert_allclose(got, expected)
+
+
+def test_pdf():
+    df = 1
+    loc = 2
+    scale = 3
+    x = np.linspace(loc + 0.1, loc + 5, 10)
+    got = chi2.pdf(x, df, loc, scale)
+    expected = sc.chi2.pdf(x, df, loc=loc, scale=scale)
+    assert_allclose(got, expected)
+
+
+def test_logpdf():
+    df = 1
+    loc = 2
+    scale = 3
+    x = np.linspace(loc + 0.1, loc + 5, 10)
+    got = chi2.logpdf(x, df, loc, scale)
+    expected = sc.chi2.logpdf(x, df, loc=loc, scale=scale)
+    assert_allclose(got, expected)
+
+
+def test_cdf():
+    df = 1
+    loc = 2
+    scale = 3
+    x = np.linspace(loc + 0.1, loc + 5, 10)
+    got = chi2.cdf(x, df, loc, scale)
+    expected = sc.chi2.cdf(x, df, loc=loc, scale=scale)
+    assert_allclose(got, expected)
+
+
+def test_ppf():
+    df = 4
+    loc = 3
+    scale = 4
+
+    p = np.linspace(0, 1, 10)
+    got = chi2.ppf(p, df, loc, scale)
+    expected = sc.chi2.ppf(p, df, loc=loc, scale=scale)
+    assert_allclose(got, expected)
+
+    got = chi2.ppf(0.5, df, loc, scale)
+    expected = sc.chi2.ppf(0.5, df, loc=loc, scale=scale)
+    assert_allclose(got, expected)
+
+
+def test_rvs():
+    df = 4
+    loc = 3
+    scale = 4
+    x = chi2.rvs(df, loc, scale, size=100_000, random_state=1)
+    r = sc.kstest(x, lambda x: chi2.cdf(x, df, loc, scale))
+    assert r.pvalue > 0.01
+
+
+@pytest.mark.filterwarnings("error")
+@pytest.mark.parametrize("fn", [chi2.logpdf, chi2.pdf, chi2.cdf])
+@pytest.mark.parametrize("parallel", [False, True])
+def test_njit(fn, parallel):
+    @nb.njit(parallel=parallel, fastmath=True)
+    def test(x):
+        return fn(x, 0.0, 1.0, 2.0)
+
+    x = np.linspace(1.1, 5.0, 1000)
+    y = test(x)
+
+    assert_allclose(y, fn(x, 0, 1, 2))

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -1,0 +1,76 @@
+import numba as nb
+import numpy as np
+import pytest
+import scipy.stats as sc
+from numpy.testing import assert_allclose
+
+from numba_stats import gamma
+
+
+def test_pdf_one():
+    alpha = 1
+    loc = 2
+    scale = 3
+    x = loc + 1
+    got = gamma.pdf(x, alpha, loc, scale)
+    expected = sc.gamma.pdf(x, alpha, loc=loc, scale=scale)
+    assert_allclose(got, expected)
+
+
+def test_pdf():
+    alpha = 1
+    loc = 2
+    scale = 3
+    x = np.linspace(loc + 0.1, loc + 5, 10)
+    got = gamma.pdf(x, alpha, loc, scale)
+    expected = sc.gamma.pdf(x, alpha, loc=loc, scale=scale)
+    assert_allclose(got, expected)
+
+
+def test_logpdf():
+    alpha = 1
+    loc = 2
+    scale = 3
+    x = np.linspace(loc + 0.1, loc + 5, 10)
+    got = gamma.logpdf(x, alpha, loc, scale)
+    expected = sc.gamma.logpdf(x, alpha, loc=loc, scale=scale)
+    assert_allclose(got, expected)
+
+
+def test_cdf():
+    alpha = 1
+    loc = 2
+    scale = 3
+    x = np.linspace(loc + 0.1, loc + 5, 10)
+    got = gamma.cdf(x, alpha, loc, scale)
+    expected = sc.gamma.cdf(x, alpha, loc=loc, scale=scale)
+    assert_allclose(got, expected)
+
+
+def test_ppf():
+    alpha = 4
+    loc = 3
+    scale = 4
+
+    p = np.linspace(0, 1, 10)
+    got = gamma.ppf(p, alpha, loc, scale)
+    expected = sc.gamma.ppf(p, alpha, loc=loc, scale=scale)
+    assert_allclose(got, expected)
+
+    got = gamma.ppf(0.5, alpha, loc, scale)
+    expected = sc.gamma.ppf(0.5, alpha, loc=loc, scale=scale)
+    assert_allclose(got, expected)
+
+
+@pytest.mark.filterwarnings("error")
+@pytest.mark.parametrize("fn", [gamma.logpdf, gamma.pdf, gamma.cdf])
+@pytest.mark.parametrize("parallel", [False, True])
+def test_njit(fn, parallel):
+    @nb.njit(parallel=parallel, fastmath=True)
+    def test(x):
+        return fn(x, 0.0, 1.0, 2.0)
+
+    x = np.linspace(1.1, 5.0, 1000)
+    y = test(x)
+
+    assert_allclose(y, fn(x, 0, 1, 2))

--- a/tests/test_ncx2.py
+++ b/tests/test_ncx2.py
@@ -1,0 +1,81 @@
+import numba as nb
+import numpy as np
+import pytest
+import scipy.stats as sc
+from numpy.testing import assert_allclose
+
+from numba_stats import ncx2
+
+
+def test_pdf_one():
+    df = 4
+    nc = 2
+    loc = 3
+    scale = 4
+    x = loc + 1
+    got = ncx2.pdf(x, df, nc, loc, scale)
+    expected = sc.ncx2.pdf(x, df, nc, loc=loc, scale=scale)
+    assert_allclose(got, expected)
+
+
+def test_pdf():
+    df = 4
+    nc = 2
+    loc = 3
+    scale = 4
+    x = np.linspace(loc + 0.1, loc + 5, 10)
+    got = ncx2.pdf(x, df, nc, loc, scale)
+    expected = sc.ncx2.pdf(x, df, nc, loc=loc, scale=scale)
+    assert_allclose(got, expected)
+
+
+def test_logpdf():
+    df = 4
+    nc = 2
+    loc = 3
+    scale = 4
+    x = np.linspace(loc + 0.1, loc + 5, 10)
+    got = ncx2.logpdf(x, df, nc, loc, scale)
+    expected = sc.ncx2.logpdf(x, df, nc, loc=loc, scale=scale)
+    assert_allclose(got, expected)
+
+
+def test_cdf():
+    df = 4
+    nc = 2
+    loc = 3
+    scale = 4
+    x = np.linspace(loc + 0.1, loc + 5, 10)
+    got = ncx2.cdf(x, df, nc, loc, scale)
+    expected = sc.ncx2.cdf(x, df, nc, loc=loc, scale=scale)
+    assert_allclose(got, expected)
+
+
+def test_ppf():
+    df = 4
+    nc = 2
+    loc = 3
+    scale = 4
+
+    p = np.linspace(0, 1, 10)
+    got = ncx2.ppf(p, df, nc, loc, scale)
+    expected = sc.ncx2.ppf(p, df, nc, loc=loc, scale=scale)
+    assert_allclose(got, expected)
+
+    got = ncx2.ppf(0.5, df, nc, loc, scale)
+    expected = sc.ncx2.ppf(0.5, df, nc, loc=loc, scale=scale)
+    assert_allclose(got, expected)
+
+
+@pytest.mark.filterwarnings("error")
+@pytest.mark.parametrize("fn", [ncx2.logpdf, ncx2.pdf, ncx2.cdf])
+@pytest.mark.parametrize("parallel", [False, True])
+def test_njit(fn, parallel):
+    @nb.njit(parallel=parallel, fastmath=True)
+    def test(x):
+        return fn(x, 0.0, 1.0, 2.0, 3.0)
+
+    x = np.linspace(1.1, 5.0, 1000)
+    y = test(x)
+
+    assert_allclose(y, fn(x, 0, 1, 2, 3))


### PR DESCRIPTION
Implements the chi square, noncentral chi square, and gamma distributions.Noncentral chi square distribution name ncx2 is taken to match scipy. All three distributions rely heavily on cython special functions from scipy, so I'm not sure if there's any performance benefit to wrapping them in numba like the other distributions in this repo. Probably there is no benefit, so adding these functions to numba-stats has questionable utility.

I've implemented the same loc, scale transformations like scipy has, but I'm not sure it's in the spirit of numba-stats to provide that functionality through either required or optional parameters. If the built-in loc, scale transformation should be kept, maybe it makes sense to set default values `loc = 0, scale = 1` throughout the code. Maybe it makes more sense to remove them.

Both of the chi2 distributions are used in statistical tests. The non-central version is less common but is used in tests from [this paper](https://arxiv.org/pdf/1007.1727) for discovery of weak strictly positive signals. The Gamma function is just a related function I decided to include, but I'm not sure of a direct use case in physics. 